### PR TITLE
Fix HttpClient parsing binary files as JSON

### DIFF
--- a/scripts/net/HttpClient.ts
+++ b/scripts/net/HttpClient.ts
@@ -6,6 +6,7 @@ import {injectable} from "inversify";
 import Dictionary from "../util/Dictionary";
 import * as _ from "lodash";
 
+const binaryMimeTypes = ["application/octet-stream", "application/pdf", "application/zip", "application/x-", "image/", "video/"];
 @injectable()
 class HttpClient implements IHttpClient {
 
@@ -41,32 +42,25 @@ class HttpClient implements IHttpClient {
             method: method,
             body: body,
             headers: <any>headers
-        }).then(response => {
-            let headers: Dictionary<string> = {};
+        }).then(async response => {
+            let responseHeaders: Dictionary<string> = {};
             response.headers.forEach((value, name) => {
-                headers[name.toString().toLowerCase()] = value;
+                responseHeaders[name.toString().toLowerCase()] = value;
             });
 
-            let contentType = headers["content-type"] || "";
-            if(this.isBinaryPayload(contentType)){
-                return response.blob().then(blob => [blob, response.status, response.headers]);
-            } else {
-                return response.text().then(text => [contentType.match("application/json") ? JSON.parse(text) : text, response.status, response.headers])
-            }
-        }).then(data => {
-            let [payload, status, headers] = data;
-            let httpResponse = new HttpResponse(payload, status, headers);
+            let contentType = responseHeaders["content-type"] || "";
+            let payload: string | Blob = await (this.isBinaryPayload(contentType) ? response.blob() : response.text());
+            let parsedPayload: object | Blob = contentType.match("application/json") ? JSON.parse(payload.toString()) : payload;
 
-            if (status >= 400)
+            const httpResponse = new HttpResponse(parsedPayload, response.status, headers);
+            if(response.status >= 400)
                 throw httpResponse;
             return httpResponse;
         });
-
         return Rx.Observable.fromPromise(promise);
     }
 
     private isBinaryPayload(contentType: string): boolean {
-        const binaryMimeTypes = ["application/octet-stream", "application/pdf", "application/zip", "application/x-", "image/", "video/"];
         return binaryMimeTypes.some(type => !!contentType.match(type));
     }
 }

--- a/scripts/net/HttpClient.ts
+++ b/scripts/net/HttpClient.ts
@@ -46,8 +46,20 @@ class HttpClient implements IHttpClient {
             response.headers.forEach((value, name) => {
                 headers[name.toString().toLowerCase()] = value;
             });
+
+            let binaryMimeTypes = ["application/octet-stream", "application/pdf", "application/zip", "application/x-", "image/", "video/"];
+            let contentType = headers["content-type"] || "";
+
+            if(binaryMimeTypes.some(type => !!contentType.match(type))){
+                return response.blob().then(payload => {
+                    let httpResponse = new HttpResponse(payload, response.status, headers);
+                    
+                    if (response.status >= 400)
+                        throw httpResponse;
+                    return httpResponse;
+                });
+            }
             return response.text().then(text => {
-                let contentType = headers["content-type"] || "";
                 let payload = contentType.match("application/json") ? JSON.parse(text) : text;
                 let httpResponse = new HttpResponse(payload, response.status, headers);
 


### PR DESCRIPTION
I added a check on the response Content Type; the HttpClient will parse the content as a Blob if the Mime Type is:
* Binary
* PDF
* Compressed (Zip, tar, gzip, gtar)
* Compiled/Serialized (Class, Jar, Ser)
* Image
* Video

otherwise, it will parse it as a JSON, like before.